### PR TITLE
fix: Babel runner picks wrong config

### DIFF
--- a/plugins/runner-babel/src/index.ts
+++ b/plugins/runner-babel/src/index.ts
@@ -75,11 +75,7 @@ export default defineRunner(runnerOptions, async ctx => {
       partialConfig?.babelignore
     ].filter(Boolean) as string[];
 
-    const configKey = configDependencies.join('-');
-    if (!optionsByConfigKey[configKey]) {
-      optionsByConfigKey[configKey] = babel.loadOptions(partialConfig?.options);
-    }
-    const loadedOptions = optionsByConfigKey[configKey];
+    const loadedOptions = babel.loadOptions(partialConfig?.options);
 
     const cacheKeys = [
       JSON.stringify({


### PR DESCRIPTION
# Description

This PR fixes the issue when babel runner caches babel config for one file and then reuses it for another, but configs are sometimes file-specific and this can lead to the runner using a wrong config. I removed the caching part until further investigation. 

Fixes # (issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)