### PR TITLE
fix: Read files even if they have a leading dot

### DIFF
--- a/core/garment/__tests__/garment.test.ts
+++ b/core/garment/__tests__/garment.test.ts
@@ -1,0 +1,66 @@
+import { executeRunner2, initFixtureHelper } from '@garment/fixture-helper';
+import * as Path from 'path';
+import { createFileInput } from '../src';
+
+const { initFixture, clean } = initFixtureHelper(module, {
+  tempDir: Path.join(__dirname, '/tmp__')
+});
+
+afterAll(clean);
+
+describe('createFileInput', () => {
+  test('It does basic glob pattern matching', async () => {
+    const includedExtension = '.js';
+    const excludedName = 'exclude-me';
+
+    const testDir = await initFixture('basic', {
+      files: {
+        [`index${includedExtension}`]: 'mock content',
+        [`some-name-${excludedName}-file${includedExtension}`]: 'mock content',
+        'something.html': 'mock content'
+      }
+    });
+
+    const input = createFileInput({
+      rootDir: testDir,
+      include: [`*${includedExtension}`],
+      exclude: [`*${excludedName}*`]
+    });
+
+    let filesCount = 0;
+    for (let file of input) {
+      const { name, ext } = Path.parse(file.path);
+      expect(ext).toBe(includedExtension);
+      expect(name).not.toContain(excludedName);
+
+      filesCount++;
+    }
+
+    expect(filesCount).toBe(1);
+  });
+
+  test('glob pattern matching includes files whose names begin with a dot', async () => {
+    const testDir = await initFixture('basic', {
+      files: {
+        '.gitignore': 'mock content',
+        '.npmrc': 'more mock content'
+      }
+    });
+
+    // We need a file in fixtures directory to keep in source control for initFixture
+    const fixtureKeep = '.gitkeep';
+    const allFilesGlob = '*';
+    const input = createFileInput({
+      rootDir: testDir,
+      include: [allFilesGlob],
+      exclude: [fixtureKeep]
+    });
+
+    let filesCount = 0;
+    for (let file of input) {
+      filesCount++;
+    }
+
+    expect(filesCount).toBe(2);
+  });
+});

--- a/core/garment/package.json
+++ b/core/garment/package.json
@@ -25,6 +25,7 @@
   ],
   "devDependencies": {
     "@types/is-valid-path": "^0.1.0",
-    "@types/tempy": "^0.2.0"
+    "@types/tempy": "^0.2.0",
+    "@garment/fixture-helper": "^0.13.8"
   }
 }

--- a/core/garment/src/garment.ts
+++ b/core/garment/src/garment.ts
@@ -1061,7 +1061,7 @@ async function garmentFromWorkspace(
 export default garment;
 export { garment, garmentFromWorkspace };
 
-function* createFileInput(
+export function* createFileInput(
   { rootDir, files = [], include, exclude = [] }: Input,
   fsInstance = fs
 ) {
@@ -1069,7 +1069,8 @@ function* createFileInput(
     ? globby.sync(include, {
         cwd: rootDir,
         absolute: true,
-        ignore: exclude
+        ignore: exclude,
+        dot: true
       })
     : [];
   const uniqueFiles = new Set([...files, ...filesFromGlob]);

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -242,11 +242,11 @@ Defines which files are sent as an input to the runner. If defined as an object,
 {
   "rootDir": "{{projectDir}}/src",
   "include": ["**/*.js"],
-  "ignore": []
+  "exclude": []
 }
 ```
 
-`rootDir: string` defines where the input files are. `include: string[]` and `ignore: string[]` define glob patterns to include to or exclude from files set. Note, that each runner can have a default `include` and `ignore` patterns, so the developer only needs to define a `rootDir`. If `input` is a `string` then it defines a `rootDir` and uses default values `[**/*]` for include and `[]` for ignore, or the ones defined by runner.
+`rootDir: string` defines where the input files are. `include: string[]` and `exclude: string[]` define glob patterns to include to or exclude from files set. Note, that each runner can have a default `include` and `exclude` patterns, so the developer only needs to define a `rootDir`. If `input` is a `string` then it defines a `rootDir` and uses default values `[**/*]` for include and `[]` for exclude, or the ones defined by runner.
 
 If not specified, the files from previous tasks will be passed as input files. If you want to receive both files from the disk and previous tasks, you should specify `pipe` option as `true` or glob pattern;
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clean": "yarn gr clean && tsc -b --clean",
     "lint": "echo Everything seems good!",
     "test": "yarn gr test",
+    "test-debug": "node --inspect-brk node_modules/@garment/cli/lib/cli.js test --runInBand", 
     "bump": "lerna version -m 'chore: Release' --conventional-commits",
     "bump:pre": "lerna version prerelease --no-git-tag-version --no-push",
     "publish": "yarn gr publish",


### PR DESCRIPTION
# Description

Garment was ignoring files with a leading dot.  This was due to fast-glob initializing the dot option to false.  This PR sets it to true.  I need this due to a generator I am building in Typescript and building with garment in which I want to copy boilerplate files such as `.npmrc.template`, `.gitignore.template`, etc.  The copy runner is skipping these files.

Fixes #2 

## How Has This Been Tested?

Awaiting feedback on issue #3 before proceeding with a testing strategy.

The change has been tested manually however by modifying my local node_modules code.

UPDATE:  Unit tests added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)