### PR TITLE
fix(runner-ts): Add path to the cacheKeys to fix #14

### DIFF
--- a/plugins/runner-ts/__tests__/__snapshots__/default.test.ts.snap
+++ b/plugins/runner-ts/__tests__/__snapshots__/default.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "collectedOutput": Array [
     Object {
       "cacheKeys": Array [
+        "index.ts",
         "3.8.3",
         "{\\"target\\":\\"es5\\",\\"module\\":\\"commonjs\\",\\"moduleResolution\\":\\"node\\",\\"declaration\\":true,\\"sourceMap\\":true,\\"noEmitOnError\\":true,\\"skipLibCheck\\":true}",
         "export const foo: number = 420;",
@@ -57,6 +58,7 @@ Object {
   "collectedOutput": Array [
     Object {
       "cacheKeys": Array [
+        "index.ts",
         "3.8.3",
         "{\\"declaration\\":true,\\"sourceMap\\":true,\\"noEmitOnError\\":true,\\"skipLibCheck\\":true,\\"target\\":\\"es5\\",\\"module\\":\\"esnext\\",\\"moduleResolution\\":\\"node\\"}",
         "export const greet = (str: string) => \`Hello, \${str}\`",
@@ -109,6 +111,7 @@ Object {
   "collectedOutput": Array [
     Object {
       "cacheKeys": Array [
+        "index.ts",
         "3.8.3",
         "{\\"declaration\\":true,\\"sourceMap\\":true,\\"noEmitOnError\\":true,\\"skipLibCheck\\":true,\\"target\\":\\"es5\\",\\"module\\":\\"esnext\\",\\"moduleResolution\\":\\"node\\"}",
         "export const greet = (str: string) => \`Hello, \${str}\`",
@@ -161,6 +164,7 @@ Object {
   "collectedOutput": Array [
     Object {
       "cacheKeys": Array [
+        "nested/index.ts",
         "3.8.3",
         "{\\"target\\":\\"es5\\",\\"module\\":\\"commonjs\\",\\"moduleResolution\\":\\"node\\",\\"declaration\\":true,\\"sourceMap\\":true,\\"noEmitOnError\\":true,\\"skipLibCheck\\":true}",
         "export const foo: number = 420;",
@@ -191,6 +195,7 @@ exports.foo = 420;
     },
     Object {
       "cacheKeys": Array [
+        "main/index.ts",
         "3.8.3",
         "{\\"target\\":\\"es5\\",\\"module\\":\\"commonjs\\",\\"moduleResolution\\":\\"node\\",\\"declaration\\":true,\\"sourceMap\\":true,\\"noEmitOnError\\":true,\\"skipLibCheck\\":true}",
         "import { foo } from \\"../nested\\"; console.log(foo);",

--- a/plugins/runner-ts/src/index.ts
+++ b/plugins/runner-ts/src/index.ts
@@ -167,7 +167,7 @@ export default defineRunner(tsRunnerOptions, async ctx => {
     const outputs = [];
 
     for (const file of filesToProcess) {
-      const { absolutePath, baseDir, path, data } = file;
+      const { absolutePath, baseDir, path } = file;
       const fileName = absolutePath ?? path;
 
       const sourceFile = host.getSourceFile(
@@ -182,7 +182,7 @@ export default defineRunner(tsRunnerOptions, async ctx => {
 
       const outputContainer = ctx.createOutputContainer(
         file,
-        [...cacheKeys, ...allDepsContent],
+        [path, ...cacheKeys, ...allDepsContent],
         directDepsRealPaths
       );
 


### PR DESCRIPTION
# Description

Path of the processed file is added to the output's cacheKeys so if the file structure of the project changes, cache is invalidated

Fixes #14 

## How Has This Been Tested?

Updated snapshots

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)