### PR TITLE
fix: Wrong baseDir in a watch mode

### DIFF
--- a/core/garment/src/garment.ts
+++ b/core/garment/src/garment.ts
@@ -97,6 +97,7 @@ type Subscription =
     }
   | {
       type: 'file';
+      baseDir: string;
       path: string;
       targetPath: string;
       level: SubscriptionLevel;
@@ -356,7 +357,7 @@ async function garmentFromWorkspace(
               const rootDir =
                 subscription.type === 'glob'
                   ? subscription.input.rootDir
-                  : project.fullPath;
+                  : subscription.baseDir
 
               const files = Object.keys(changes)
                 .map(changedFilePath =>
@@ -416,6 +417,7 @@ async function garmentFromWorkspace(
                           type: 'file',
                           level: 'input',
                           path: dependency,
+                          baseDir: output.targetBaseDir,
                           targetPath: output.target
                         });
                       }
@@ -567,6 +569,7 @@ async function garmentFromWorkspace(
                   type: 'file',
                   level: 'runner',
                   path,
+                  baseDir: Path.dirname(path),
                   targetPath: path
                 });
               }
@@ -615,6 +618,7 @@ async function garmentFromWorkspace(
                       type: 'file',
                       level: 'input',
                       path: dependency,
+                      baseDir: output.targetBaseDir,
                       targetPath: output.target
                     });
                   }
@@ -634,6 +638,7 @@ async function garmentFromWorkspace(
                     type: 'file',
                     level: handlerOutput.target ? 'input' : 'runner',
                     path: dependency,
+                    baseDir: handlerOutput.targetBaseDir,
                     targetPath: handlerOutput.target ?? dependency
                   });
                 }

--- a/core/runner/src/OutputContainer.ts
+++ b/core/runner/src/OutputContainer.ts
@@ -1,6 +1,7 @@
 import { Level, Logger } from '@garment/logger';
 import { File } from './types';
 import { createHash } from 'crypto';
+import * as Path from 'path';
 
 export interface CacheProvider<T = any> {
   has(id: string): Promise<boolean> | boolean;
@@ -27,6 +28,8 @@ export class OutputContainer {
   readonly hash: string;
   readonly target: string;
 
+  targetBaseDir: string;
+
   constructor(
     public readonly cacheProvider: CacheProvider,
     target: string | File,
@@ -39,8 +42,14 @@ export class OutputContainer {
     }
     this.hash = hash.digest('hex');
 
-    this.target =
-      typeof target === 'string' ? target : target.absolutePath ?? target.path;
+    if (typeof target === 'string') {
+      this.target = target;
+      this.targetBaseDir = Path.dirname(target);
+    } else {
+      this.target = target.absolutePath ?? target.path;
+      this.targetBaseDir = target.baseDir ?? Path.dirname(this.target);
+    }
+
     this.dependencies = dependencies.map(dep =>
       typeof dep === 'string' ? dep : dep.absolutePath ?? dep.path
     );


### PR DESCRIPTION
# Description

When in watch mode the task is triggered for the specific file, it has a wrong baseDir and thus treats it like a different file and can't find it in the cache

## How Has This Been Tested?

Ran

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)