### PR TITLE
fix: Clarify error message when non-magical part of input glob does not exist

### DIFF
--- a/core/garment/__tests__/garment.test.ts
+++ b/core/garment/__tests__/garment.test.ts
@@ -63,4 +63,21 @@ describe('createFileInput', () => {
 
     expect(filesCount).toBe(2);
   });
+
+  test('should throw with a clear error message when rootDir does not exist', async () => {
+    const testDir = await initFixture('basic');
+
+    const nonExistingDirectory = Path.join(testDir, 'nonExistingDirectory');
+    const generator = createFileInput({
+      rootDir: nonExistingDirectory
+    });
+
+    const createFileInputForNonExistingRootDirectory = () => {
+      generator.next();
+    };
+
+    expect(createFileInputForNonExistingRootDirectory).toThrow(
+      /nonExistingDirectory/
+    );
+  });
 });

--- a/core/garment/src/garment.ts
+++ b/core/garment/src/garment.ts
@@ -1083,6 +1083,11 @@ export function* createFileInput(
   { rootDir, files = [], include, exclude = [] }: Input,
   fsInstance = fs
 ) {
+  if (!fsInstance.existsSync(rootDir)) {
+    throw new Error(`The path ${rootDir} does not exist, please check the input property
+     of your tasks in your garment.json file and verify that the "non-magical" part of your glob
+     is a path to an already existing directory`);
+  }
   const filesFromGlob = include
     ? globby.sync(include, {
         cwd: rootDir,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -246,7 +246,7 @@ Defines which files are sent as an input to the runner. If defined as an object,
 }
 ```
 
-`rootDir: string` defines where the input files are. `include: string[]` and `exclude: string[]` define glob patterns to include to or exclude from files set. Note, that each runner can have a default `include` and `exclude` patterns, so the developer only needs to define a `rootDir`. If `input` is a `string` then it defines a `rootDir` and uses default values `[**/*]` for include and `[]` for exclude, or the ones defined by runner.
+`rootDir: string` defines where the input files are. `include: string[]` and `exclude: string[]` define glob patterns to include to or exclude from files set. Note, that each runner can have a default `include` and `exclude` patterns, so the developer only needs to define a `rootDir`. If `input` is a `string` then it defines a `rootDir` and uses default values `[**/*]` for include and `[]` for exclude, or the ones defined by runner.  Note that `rootDir` must exist and that when using globs, the non-magical part (the part before the first glob character) must exist.
 
 If not specified, the files from previous tasks will be passed as input files. If you want to receive both files from the disk and previous tasks, you should specify `pipe` option as `true` or glob pattern;
 


### PR DESCRIPTION
# Description

Currently, there is an obscure error message given when rootDir does not exist on the filesystem.  This error was confusing to developers and was not helpful in pinpointing the cause of the issue.

Please consider if the error message I provided can be further improved in some way.

Also please consider the performance implications.  I could have put the check in the action graph construction which is only run once, but it's a bit far from the code which causes the error.

Fixes #11

## How Has This Been Tested?

Unit tested.  Also integration tested in a consuming project.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)