### PR TITLE
fix: Error for non-existant rootDir should not throw for virtual fs

### DIFF
--- a/core/garment/src/garment.ts
+++ b/core/garment/src/garment.ts
@@ -753,13 +753,14 @@ async function garmentFromWorkspace(
         const outputPaths = output ? [...arrayfy(output)] : [];
         if (
           currentActionGraph.getDirectDependantsOf(action).length &&
-          !outputPaths.length
+          !outputPaths.length &&
+          filesToWrite.length
         ) {
           // if there was no "output" option provided but the action is in the chain and has a next action
-          // we create a temporary path for output to the memfs
+          // and the current action has output, we create a temporary path for output to the memfs
           outputPaths.push(actionToOutputPath(action));
         }
-        if (meta) {
+        if (meta && outputPaths.length) {
           meta.outputPath = outputPaths[0]; // Next actions can use this output path to create an input
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "gr": "node local_garment/node_modules/.bin/garment",
+    "gr": "node local_garment/node_modules/@garment/cli/lib/cli.js",
     "gr:local": "node core/cli/lib/cli.js",
     "build": "yarn gr build",
     "build:ci": "yarn gr build --ts.configFile tsconfig.ci.json",


### PR DESCRIPTION
# Description

Fix issue to allow files to not exist in virtual file system in createFileInput function.

Fixes #22 

## How Has This Been Tested?

Tested in a separate repo with a lifecycle hook.  Verified that the bug appeared and that using my code prevented the bug.  Also created a unit test.

@beshanoe I had to be restrictive with the types accepted by createFileInput.  For example, it does not accept the fs export of memFS as that [is just a POJO](https://github.com/streamich/memfs/blob/master/src/index.ts) instead of a class and so runtime type-checking can't be used to branch the execution.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)