### PR TITLE
Improve cache subscriptions

### DIFF
--- a/core/garment/package.json
+++ b/core/garment/package.json
@@ -10,7 +10,7 @@
     "@garment/scheduler": "^0.13.13",
     "@garment/schema-validator": "^0.13.13",
     "@garment/workspace": "^0.13.13",
-    "@parcel/watcher": "^2.0.0-alpha.5",
+    "@parcel/watcher": "^2.0.0-alpha.9",
     "fs-extra": "8.1.0",
     "is-valid-path": "^0.1.1",
     "matcher": "^2.1.0",

--- a/garment.json
+++ b/garment.json
@@ -46,9 +46,7 @@
       "tasks": {
         "clean": {
           "runner": "clean",
-          "input": {
-            "include": ["tsconfig.tsbuildinfo", "lib"]
-          }
+          "input": "{{projectDir}}/lib/**/*"
         },
         "test": {
           "runner": "jest",
@@ -68,7 +66,6 @@
             "delay": 10
           }
         },
-        "prebuild": ":clean",
         "build": {
           "runner": "ts",
           "input": "{{projectDir}}/src/**/*.ts?(x)",
@@ -274,5 +271,5 @@
     }
   },
   "schematics": ["@garment/schematics", "@garment/schematics-typescript"],
-  "experimentalCacheSubscriptions": false
+  "experimentalCacheSubscriptions": true
 }

--- a/local_garment/package.json
+++ b/local_garment/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@garment/cli": "^0.13.12",
-    "@garment/plugin-runner-clean": "^0.13.8",
-    "@garment/plugin-runner-ts": "^0.13.11"
+    "@garment/cli": "^0.13.14",
+    "@garment/plugin-runner-clean": "^0.13.13",
+    "@garment/plugin-runner-ts": "^0.13.13"
   }
 }

--- a/local_garment/yarn.lock
+++ b/local_garment/yarn.lock
@@ -42,21 +42,21 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@garment/cli@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@garment/cli/-/cli-0.13.12.tgz#bfc4af2f482bbc32068731d146e2c42c1943e35c"
-  integrity sha512-FBh86ySE372B15Kol+6E9PhOoVviVFGswGlAF1tgYI/vOYfVJUCLmxLSZVXLubFraX9rUMCQm+LXccCc5JpMuw==
+"@garment/cli@^0.13.14":
+  version "0.13.14"
+  resolved "https://registry.yarnpkg.com/@garment/cli/-/cli-0.13.14.tgz#4d06f740e69e250f4155c0fbfba2ae9b1afc28bb"
+  integrity sha512-mkhIGmj8zs5b00hIfjBRel2yAEzwSHxlK6DVCHhYRy/rAsj1RNg0bhbWVbw/7nrC+8iomoLS/5MMnJzO4W6vJQ==
   dependencies:
-    "@garment/garment" "^0.13.12"
-    "@garment/logger" "^0.13.8"
-    "@garment/perf" "^0.13.8"
-    "@garment/print-tree" "^0.13.8"
-    "@garment/scheduler" "^0.13.12"
-    "@garment/schematics-client" "^0.13.8"
-    "@garment/schematics-init" "^0.13.8"
-    "@garment/visualize-graph" "^0.13.12"
-    "@garment/workspace" "^0.13.11"
-    "@garment/yeoman-client" "^0.13.8"
+    "@garment/garment" "^0.13.14"
+    "@garment/logger" "^0.13.13"
+    "@garment/perf" "^0.13.13"
+    "@garment/print-tree" "^0.13.13"
+    "@garment/scheduler" "^0.13.13"
+    "@garment/schematics-client" "^0.13.13"
+    "@garment/schematics-init" "^0.13.13"
+    "@garment/visualize-graph" "^0.13.13"
+    "@garment/workspace" "^0.13.13"
+    "@garment/yeoman-client" "^0.13.13"
     chalk "^2.4.2"
     cosmiconfig "^5.2.1"
     fs-extra "8.1.0"
@@ -64,88 +64,89 @@
     update-notifier "^3.0.1"
     yargs "15.0.2"
 
-"@garment/dependency-graph@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@garment/dependency-graph/-/dependency-graph-0.13.12.tgz#21978ef052077797c1d2103cfe359fcf044e116a"
-  integrity sha512-rLa1VYiRwIf0X9q0wcqQVnQVaSiI6MtEg5Kg0lLRZ4L6uo739wLXr9AB7GzxrEI0pAZymfbR7kfpJBHHWfoedA==
+"@garment/dependency-graph@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/dependency-graph/-/dependency-graph-0.13.13.tgz#854c5e9c0b23de8b8fde5a55d8d3eeafeabd3d81"
+  integrity sha512-6mpbwMNOTJC39984i9/ilXrWc3y9tHCO7srBFiGJKXWQUQQamkJDB904g5qpRBRds4yU+trc4zxsyfxA50r/eQ==
 
-"@garment/garment@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@garment/garment/-/garment-0.13.12.tgz#da154456d368ae20dba7bbc45cddf54f98e93ef0"
-  integrity sha512-4Q76adBNykkyL7T53NQvdIqL35kRPCcvZRYPeghDhXoIm9n5OZy9e5pjNqEJokBXIcgqC+Cic1X3p0SBGSjT+w==
+"@garment/garment@^0.13.14":
+  version "0.13.14"
+  resolved "https://registry.yarnpkg.com/@garment/garment/-/garment-0.13.14.tgz#66e9652d7bf802ad0692df8a05560285b6e0453c"
+  integrity sha512-w23QMmkBAHc1R0qbJXj7Hlbn4YPNBzoBrOsfCTEIx4Aq890eZTram+LUf5hLpGdbbkGUbIQI6XK9sjvcHYiWog==
   dependencies:
-    "@garment/dependency-graph" "^0.13.12"
-    "@garment/logger" "^0.13.8"
-    "@garment/runner" "^0.13.11"
-    "@garment/scheduler" "^0.13.12"
-    "@garment/schema-validator" "^0.13.8"
-    "@garment/workspace" "^0.13.11"
+    "@garment/dependency-graph" "^0.13.13"
+    "@garment/logger" "^0.13.13"
+    "@garment/runner" "^0.13.13"
+    "@garment/scheduler" "^0.13.13"
+    "@garment/schema-validator" "^0.13.13"
+    "@garment/workspace" "^0.13.13"
     "@parcel/watcher" "^2.0.0-alpha.5"
     fs-extra "8.1.0"
     is-valid-path "^0.1.1"
     matcher "^2.1.0"
     memfs "^3.1.2"
     multimatch "^4.0.0"
+    normalize-path "^3.0.0"
     tempy "0.3.0"
     unionfs "^4.4.0"
 
-"@garment/logger@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/logger/-/logger-0.13.8.tgz#f3679796baa8b4939d65a40547db6e57285a414a"
-  integrity sha512-SNk3QW+TMTclpS+XD2WrrfvB3WrHyyXZ5/q+c9Hz767HgcKhigh4nf9s3HFbnVkqztW0oaYDptNc4PKgxuYlhg==
+"@garment/logger@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/logger/-/logger-0.13.13.tgz#7d8befa7393d3f315f2cd0a976581c488ea22d3f"
+  integrity sha512-XNkNeaaagGI3Dav+cGCUBlIYi9FLTh2CESfKicdZiZH4CCnR2XMoM8gekncP+NyM6uQtOLjHStkg+ohGKADRYg==
   dependencies:
     chalk "^2.4.2"
     strip-ansi "^5.2.0"
 
-"@garment/perf@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/perf/-/perf-0.13.8.tgz#f965fcdde59000664a96a89b346c6063ac0626ca"
-  integrity sha512-Y79nSDmQZ2bmK/a5qNgPe9H3FXwdxn0WY58RzDxFXUqYvywLQuQFwny7v6b0Nf1X6BxNucISdv1HRZUzxlt6JQ==
+"@garment/perf@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/perf/-/perf-0.13.13.tgz#df2f5283bc5fc43e1fa7738ffac23eaaf3bb70a2"
+  integrity sha512-oU2tVu5YUP749rpp7AaP/HIVtQpXJgSZjMpSxI9tuFTqGUl+Dlnh4DG3RAqyL4NBHu8Q3NqOKhCincOmd1c87w==
   dependencies:
-    "@garment/logger" "^0.13.8"
+    "@garment/logger" "^0.13.13"
 
-"@garment/plugin-runner-clean@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-clean/-/plugin-runner-clean-0.13.8.tgz#9b7b0740b38f8cac6cb38016c2d33996bc40cac5"
-  integrity sha512-QrEz3tlSD/TKL9+eypdJNcxp13DgAMfy6pkC/b8lFjI4+r+lypP2RdlPDAtsUL2fXh3hZzqh4iM3D+YHb8KkWQ==
+"@garment/plugin-runner-clean@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-clean/-/plugin-runner-clean-0.13.13.tgz#4170da8e63998316603175e641de2f2ecd4f7279"
+  integrity sha512-k6Z7xHfXAt+Ig1Kcn1zgGdduAdfxyG1MR55GEyCtH/3N138X+abuhDMHzT8pc1aq8CxUdrXxSYcOCsqIhqjXHg==
   dependencies:
     del "^4.0.0"
 
-"@garment/plugin-runner-ts@^0.13.11":
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-ts/-/plugin-runner-ts-0.13.11.tgz#b2c03777e263a2bd99e3dd96c61d3b338ada0b49"
-  integrity sha512-PsmiGK9OJtpXL11Hq/uTMxrO6iIb0HLi1Rbd+izQVpQP0SQl4AwitsFD5fMzcqZdqMbS4vr2tCWWJwirS9BnVQ==
+"@garment/plugin-runner-ts@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-ts/-/plugin-runner-ts-0.13.13.tgz#b399c0bbbb28dd21a3ad24fa0455d7ea93462075"
+  integrity sha512-zrfBux0RKTkZh1aX31nvhjvPUr3iD7t1+c/CX+7t9aNwBvJVCmWUppCm27+jDosimCyUcAS9uD218+Xd9uR34g==
 
-"@garment/print-tree@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/print-tree/-/print-tree-0.13.8.tgz#021d42cc85386450ee7e510e2f5c7eeadca629be"
-  integrity sha512-X9va1PMNu9pi9OEx+6+crcxOiF0rOfaskwxSfSm9kuWJU0TeX+A13gOncCO656H84fP013TKgotSskuCt+e9BA==
+"@garment/print-tree@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/print-tree/-/print-tree-0.13.13.tgz#4c2e58765159c53e29de8c4eace6882482f79613"
+  integrity sha512-4btM8LqvqHjv5mjmPS60pHvqMGgynsUF7kppVuEcVh14UykXXmSUWRbARizLnLYkGIIl3U7Ep00MJWkYVV/ZeQ==
   dependencies:
     treeify "^1.1.0"
 
-"@garment/runner@^0.13.11":
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/@garment/runner/-/runner-0.13.11.tgz#af7befaf2bae460844378a0cd7ab1f1fa29887f4"
-  integrity sha512-ICG3nlpGIaq+BuGImzvYJPHJsnjZe0SvrQBSnb6Cnff172Pjs6STLp4lIlk8e7hr1JfWurx1xGWyDKOXftWz9w==
+"@garment/runner@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/runner/-/runner-0.13.13.tgz#b764a4f6411082210dabcc925473c9648e704d9e"
+  integrity sha512-239GGVUnbrXD1Cz8BTu0H7nYrZM0i/3c7vGVZLMXQtjsFJrMJdkbbNHbE2IyAb1iluQAML5KAEKNiP2xUuc4tQ==
   dependencies:
-    "@garment/logger" "^0.13.8"
-    "@garment/schema-validator" "^0.13.8"
-    "@garment/watcher" "^0.13.8"
-    "@garment/workspace" "^0.13.11"
+    "@garment/logger" "^0.13.13"
+    "@garment/schema-validator" "^0.13.13"
+    "@garment/watcher" "^0.13.13"
+    "@garment/workspace" "^0.13.13"
     "@types/fs-extra" "^5.0.5"
     fs-extra "8.1.0"
     mustache "^3.0.1"
 
-"@garment/scheduler@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@garment/scheduler/-/scheduler-0.13.12.tgz#ccdaf19c99eded622732fc54cadba7a36518182f"
-  integrity sha512-Jd4HaZbO7K5B213tDatHpzGG2xadZ9uBEYBDFi7MKmZUuYmD7O1OCAno0wsdSIfvHEGEhNsWWMRI7tMONkqMTQ==
+"@garment/scheduler@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/scheduler/-/scheduler-0.13.13.tgz#386930212874e9dedf71bb3aa762ca7fb4b16fcc"
+  integrity sha512-bDzxbHr+rgJa7eo15CxzUg71dwFtKnguBHIj2FSXgAYGqGgwke3LWzOjtklNbqbKVR8Kdo8jnUrrf4yv6r2wow==
   dependencies:
-    "@garment/dependency-graph" "^0.13.12"
-    "@garment/logger" "^0.13.8"
-    "@garment/runner" "^0.13.11"
-    "@garment/watcher" "^0.13.8"
-    "@garment/workspace" "^0.13.11"
+    "@garment/dependency-graph" "^0.13.13"
+    "@garment/logger" "^0.13.13"
+    "@garment/runner" "^0.13.13"
+    "@garment/watcher" "^0.13.13"
+    "@garment/workspace" "^0.13.13"
     "@types/glob-parent" "^3.1.1"
     fs-extra "8.1.0"
     glob-parent "^5.0.0"
@@ -156,68 +157,67 @@
     object-hash "^2.0.0"
     tempy "0.3.0"
 
-"@garment/schema-validator@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/schema-validator/-/schema-validator-0.13.8.tgz#d60e94b5458d41f6344aef7b2da1e2456c235da3"
-  integrity sha512-TJhkxPJKrNr/9+UIFCt7wP6mTKm1Yeu/eUsRXYqI1UYfV2lNKFauNzx99g2OUmH4nIUgYaLtKYUJGOY5TyJcug==
+"@garment/schema-validator@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/schema-validator/-/schema-validator-0.13.13.tgz#81dae1d1be070fac1db0ec60bf5a5cd21a8025ab"
+  integrity sha512-Eo/yl9Pv9LpesdYPjK9jLiTTVCAg6tJ/Xkn3ASEAxpwYFA0SkfXZgLT81Ywp5duCGx342n1oNYViDOhql1lU8Q==
   dependencies:
     ajv "^6.7.0"
 
-"@garment/schematics-client@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/schematics-client/-/schematics-client-0.13.8.tgz#efe1a65dc73fc58947d5eeae07c1eab968ae5da0"
-  integrity sha512-660VxM2E+LUPIzRzJi1hFBe1IpKDBGIvO0B9xwNvE1KHjlF5nJePcMhCzQ5asFGWGa8pNE1YS4Va5slC4jAVPg==
+"@garment/schematics-client@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/schematics-client/-/schematics-client-0.13.13.tgz#a79c5b27ea653c707fb9b18d24f92a4cc8d2bde6"
+  integrity sha512-UHljfYM1YWdTVS7prNb83w7e6ATwHqIZ9AUXFIDGYVJU3Txps6oCRbBK8z5a+1bpbRpmdyn5cnPisct1egNXiQ==
   dependencies:
     "@angular-devkit/core" "^7.3.1"
     "@angular-devkit/schematics" "^7.3.1"
     inquirer "^6.2.2"
     symbol-observable "^1.2.0"
 
-"@garment/schematics-init@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/schematics-init/-/schematics-init-0.13.8.tgz#6d0bd90b876fc55198ceec3a6e116ee597c9e464"
-  integrity sha512-lMlRUhIL5ifySXdwiSho5vnv8zZQMffFhqt6vyb+AoDlVIEpHxS2Nb0a9lcNevRhOFix+I9Jh3BuhPQh8+uLKg==
+"@garment/schematics-init@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/schematics-init/-/schematics-init-0.13.13.tgz#8e591eb9f33bf2ae15b0ad7658a4b84a5b076e69"
+  integrity sha512-CHsHgUou54/YqJL7TMOU10nHbsRgOaIATCYddBjEyUg7TffUKGmgKzgLPua0QEkvJYCc3dJqDnCl7sNsB4r6WQ==
   dependencies:
     "@angular-devkit/core" "^7.3.1"
     "@angular-devkit/schematics" "^7.3.1"
     execa "^1.0.0"
 
-"@garment/visualize-graph@^0.13.12":
-  version "0.13.12"
-  resolved "https://registry.yarnpkg.com/@garment/visualize-graph/-/visualize-graph-0.13.12.tgz#14bf640ea5e4b863bbddcb6e38884debf1314d22"
-  integrity sha512-bt2JpcY0RJuGhK9W86UtmeNX1vQCgr6Rot+hGtF6hLrhPY8d2SUNqkUBM3g4GOwb6RULgUy+hlNoduCsRjSX6w==
+"@garment/visualize-graph@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/visualize-graph/-/visualize-graph-0.13.13.tgz#a3fa30e8e527de882591ce49f0e73e6fa9095e73"
+  integrity sha512-vnKD95a/hlN1jMWgDISzhpeYy+xxJx5vWhEYWE54RgIZXfMoXFBiA4UpOhX/UKxn86Ev5Umv03KpUlAK05ta7A==
   dependencies:
-    "@garment/dependency-graph" "^0.13.12"
+    "@garment/dependency-graph" "^0.13.13"
     fs-extra "8.1.0"
     graphviz "^0.0.8"
     opn "^5.4.0"
     tmp "^0.0.33"
     viz.js "^2.1.2"
 
-"@garment/watcher@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/watcher/-/watcher-0.13.8.tgz#d98c85795037f38e7074e7467914ab48c61cfa3c"
-  integrity sha512-KLkW7EF6LYXGcNxaj0NRiG/mnKu4M/mlh+oglkRM/PjL7SbQD6PKk2jmnj7LtAuzY6EkLyizqZBfH9er6TITSw==
+"@garment/watcher@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/watcher/-/watcher-0.13.13.tgz#686244d57b38febc8d077fb2349f769afea0d793"
+  integrity sha512-sM4KZWvKBYBXmAgmgPesfw4LUiJ/o+jfF+Smj7+S1yjHPdD7TA1CU5oFwo4kheqhSoMF73vIgZo4tvnT+35Diw==
   dependencies:
     chokidar "^2.1.5"
 
-"@garment/workspace@^0.13.11":
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/@garment/workspace/-/workspace-0.13.11.tgz#0c2b6ba2f72ce2f2a3ab61c3965a5ff4337bec61"
-  integrity sha512-Gtz88HgCPnpge+OAAw/eK9Pv4/hpsQm5SpAobQmDDPUKAxR0qoo08nlLpIcQatY0HDuYbzJd3dTysX3rKsVsww==
+"@garment/workspace@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/workspace/-/workspace-0.13.13.tgz#72953e93968180333dab883e714d1dbdf88fe46a"
+  integrity sha512-SfssnVVwGTgy3xnFcC4omszwC1IM55ecyA55O8ITNA2SyeqnhRxFofXsi14ah46nOLr9ytNmBIzqp708SCkFMA==
   dependencies:
-    "@garment/logger" "^0.13.8"
-    "@garment/schema-validator" "^0.13.8"
+    "@garment/schema-validator" "^0.13.13"
     dependency-graph "^0.8.0"
     fs-extra "8.1.0"
     mustache "^3.0.1"
     normalize-path "^3.0.0"
     object-hash "^2.0.0"
 
-"@garment/yeoman-client@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@garment/yeoman-client/-/yeoman-client-0.13.8.tgz#a1d02c65929355a95e2a577bde2b2ee2688e4f29"
-  integrity sha512-NeM1PCkD9u+cZiyN3ILYsG5ArpodAYIRLd2QOQ7BA2nf6+7AUrYUod7ojaDFmbPjMqGiP5GJuTXBY3ONnTA5OQ==
+"@garment/yeoman-client@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@garment/yeoman-client/-/yeoman-client-0.13.13.tgz#cebb19fa42fb39a272337dc9bc956751705d837b"
+  integrity sha512-1N/aNhsQyGCkrMHLHMDd3UdQCsGdo9roMAe0Vi2oBym1zbLbRI2J0IYUIMi+O3WsDKuIVqa9PQKl8kIZb6Z3oA==
   dependencies:
     globby "10.0.1"
     yeoman-environment "^2.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,14 +2688,13 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@parcel/watcher@^2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0-alpha.5.tgz#b16e8af9e6cccf249e094075071701d01f73a1be"
-  integrity sha512-QE5S2KgyM04pCECr+ZbwKZuzNrrV5eUadPYDhSRdrVc9uOIXfxUPGHgRsp99g+No9Zo+FI9EWL9jEiHmmAb77A==
+"@parcel/watcher@^2.0.0-alpha.9":
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0-alpha.9.tgz#58010b069a8e64f0c3d0059263f6a525522398d2"
+  integrity sha512-k3luHa2W4W42uAe85v61HFMJKBf8txJmEJBB4BlHuNoFomA7lLX35nsg1APFYS/HKvf0oIEqEL1HvPRx+Dt+QA==
   dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.6.2"
-    prebuild-install "^5.2.5"
+    node-addon-api "^3.0.2"
+    node-gyp-build "^4.2.3"
 
 "@reach/router@^1.2.1":
   version "1.3.3"
@@ -6834,13 +6833,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -7007,11 +6999,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -8015,11 +8002,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expand-template@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
-  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
-
 expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
@@ -8885,11 +8867,6 @@ gitconfiglocal@^1.0.0:
   integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
   dependencies:
     ini "^1.3.2"
-
-github-from-package@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
-  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -12205,11 +12182,6 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -12512,11 +12484,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-napi-build-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
-  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
-
 native-url@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae"
@@ -12610,17 +12577,10 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-abi@^2.7.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.15.0.tgz#51d55cc711bd9e4a24a572ace13b9231945ccb10"
-  integrity sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==
-  dependencies:
-    semver "^5.4.1"
-
-node-addon-api@^1.6.2:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
-  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
+node-addon-api@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
+  integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -12647,6 +12607,11 @@ node-forge@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
   integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
+
+node-gyp-build@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp@^5.0.2:
   version "5.1.0"
@@ -12733,11 +12698,6 @@ node-source-walk@^4.0.0, node-source-walk@^4.2.0:
   integrity sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==
   dependencies:
     "@babel/parser" "^7.0.0"
-
-noop-logger@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
-  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -12901,7 +12861,7 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -14008,27 +13968,6 @@ postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.13, postcss@^7.0.14,
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prebuild-install@^5.2.5:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"
-  integrity sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
-
 precinct@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/precinct/-/precinct-6.2.0.tgz#1755c369316d58ffeed2332a31442d5498f3cc33"
@@ -14444,7 +14383,7 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -15812,15 +15751,6 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
-simple-get@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
-  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
 simple-get@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.0.3.tgz#924528ac3f9d7718ce5e9ec1b1a69c0be4d62efa"
@@ -16652,17 +16582,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-fs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
-  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
-  dependencies:
-    chownr "^1.1.1"
-    mkdirp "^0.5.1"
-    pump "^3.0.0"
-    tar-stream "^2.0.0"
-
-tar-stream@^2.0.0, tar-stream@^2.1.0:
+tar-stream@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
   integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
@@ -17933,11 +17853,6 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
-which-pm-runs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
-  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@^1.2.10, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
# Description

The idea is to further improve the cache subscriptions mechanism, namely the one which allows us to save the last state of the monorepo and run tasks only over the changed files after it. It somewhat worked already, but one of the bugs was that if the output files of the task were removed, Garment would still think the project is consistent because the input files haven't been changed. I addressed it by creating a subscription for each output file, so if the output has been removed or manually changed, Garment would rerun the whole task. In the future we can also make it rerun the task only for the particular file responsible for that changed output. 
During the work, I also noticed some major flaws in the mechanism and fixed them too.

Fixes # (issue)

## How Has This Been Tested?

Only manually in the Garment repo itself

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)