### PR TITLE
fix: Error for rootDir only when necessary

### DIFF
--- a/core/garment/__tests__/garment.test.ts
+++ b/core/garment/__tests__/garment.test.ts
@@ -64,20 +64,19 @@ describe('createFileInput', () => {
     expect(filesCount).toBe(2);
   });
 
-  test('should throw with a clear error message when rootDir does not exist', async () => {
+  test('should NOT throw when rootDir does not exist, allowing for input globs in garment.json whose rootDir may or may not exist', async () => {
     const testDir = await initFixture('basic');
 
     const nonExistingDirectory = Path.join(testDir, 'nonExistingDirectory');
     const generator = createFileInput({
-      rootDir: nonExistingDirectory
+      rootDir: nonExistingDirectory,
+      include: ['*']
     });
 
     const createFileInputForNonExistingRootDirectory = () => {
       generator.next();
     };
 
-    expect(createFileInputForNonExistingRootDirectory).toThrow(
-      /nonExistingDirectory/
-    );
+    expect(createFileInputForNonExistingRootDirectory).not.toThrow();
   });
 });

--- a/core/garment/package.json
+++ b/core/garment/package.json
@@ -18,7 +18,8 @@
     "multimatch": "^4.0.0",
     "normalize-path": "^3.0.0",
     "tempy": "0.3.0",
-    "unionfs": "^4.4.0"
+    "unionfs": "^4.4.0",
+    "globby": "10.0.1"
   },
   "files": [
     "lib",

--- a/core/garment/src/garment.ts
+++ b/core/garment/src/garment.ts
@@ -1127,19 +1127,16 @@ export function* createFileInput(
   { rootDir, files = [], include, exclude = [] }: Input,
   fsInstance = fs
 ) {
-  if (!fsInstance.existsSync(rootDir)) {
-    throw new Error(`The path ${rootDir} does not exist, please check the input property
-     of your tasks in your garment.json file and verify that the "non-magical" part of your glob
-     is a path to an already existing directory`);
-  }
-  const filesFromGlob = include
-    ? globby.sync(include, {
-        cwd: rootDir,
-        absolute: true,
-        ignore: exclude,
-        dot: true
-      })
-    : [];
+  const filesFromGlob =
+    fsInstance === fs && include && fsInstance.existsSync(rootDir)
+      ? globby.sync(include, {
+          cwd: rootDir,
+          absolute: true,
+          ignore: exclude,
+          dot: true
+        })
+      : [];
+
   const uniqueFiles = new Set([...files, ...filesFromGlob]);
   for (const absolutePath of uniqueFiles) {
     const content = fsInstance.readFileSync(absolutePath);


### PR DESCRIPTION
# Description

While the checking for rootDir has surfaced bugs in other locations, it is causing problems in certain cases.

!fsInstance.existsSync(rootDir) is an incorrect condition and is checking cases it shouldn't be for the following reasons:
- The main purpose of this error was to prevent globby from throwing a vague error message and to fail fast with a clear error message.  Globby does not use our fsInstance however, it always uses fs.  Therefore we only need to check when we will call globby and we must do so on fs, not fsInstance.
-  When fsInstance is Volume (memfs) fsInstance.existsSync(rootDir) will fail if rootDir is aWindows path even if that path actually exists on the physical system.

This PR makes it so that we only check when we will invoke globby, and we do so on fs, which globby uses anyway, not fsInstance.

Fixes #30 

## How Has This Been Tested?

In addition to updating the unit tests, I reproduced it locally in a monorepo using garment and made sure the error did not happen with the fix.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)