### PR TITLE
fix: #40 batch error should result in exitcode 1

### DIFF
--- a/core/cli/src/utils/status.ts
+++ b/core/cli/src/utils/status.ts
@@ -13,6 +13,7 @@ export class Status {
       logs: string[];
     }
   >();
+  private hasBatchErrors = false;
 
   private timeStartedByProject = new Map<string, number>();
 
@@ -30,7 +31,7 @@ export class Status {
   get hasErrors() {
     return Array.from(this.actionsByProjectName.values()).some(stat =>
       Boolean(stat.hasErrors)
-    );
+    ) || this.hasBatchErrors;
   }
 
   setActions(...actions: Action[]) {
@@ -188,6 +189,9 @@ export class Status {
             ...entry.content
           ).join(' ')
         );
+      }
+      if (entry.level === 'error') {
+        this.hasBatchErrors = true;
       }
     });
     this.onChange({ done, dynamic: [], height: 0 });


### PR DESCRIPTION
# Description

Before Garment would not take into account errors logged during batch runner execution in order to emit exit code 1. Now it does

Fixes #40 

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)