### PR TITLE
feat: Add workspaceDir to runner-bin

### DIFF
--- a/plugins/runner-bin/src/index.ts
+++ b/plugins/runner-bin/src/index.ts
@@ -45,7 +45,10 @@ export default defineRunner(
     const { logger, options, project, workspace, renderTemplate } = ctx;
     const { stream, env, longRunning = false } = options;
     const [binOption, ...args] = parseOptions(options).map(arg =>
-      renderTemplate(arg, { projectDir: project.fullPath })
+      renderTemplate(arg, {
+        projectDir: project.fullPath,
+        workspaceDir: workspace.cwd
+      })
     );
 
     const bin = await resolveBin(binOption, workspace.cwd);


### PR DESCRIPTION
# Description

- Add template property `{{workspaceDir}}` since bin always starts on `cwd: ctx.project.fullPath` we need a way of getting files from the workspace instead of using `{{projectDir}}/../../....`.

Fixes # (issue)

## How Has This Been Tested?

This was tested using a monorepo that uses Garment extensively.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)