### PR TITLE
feat(plugin-runner-bin): Add projectName as a template arg

### DIFF
--- a/packages/plugin-runner-bin/src/index.ts
+++ b/packages/plugin-runner-bin/src/index.ts
@@ -47,7 +47,8 @@ export default defineRunner(
     const [binOption, ...args] = parseOptions(options).map(arg =>
       renderTemplate(arg, {
         projectDir: project.fullPath,
-        workspaceDir: workspace.cwd
+        workspaceDir: workspace.cwd,
+        projectName: project.name
       })
     );
 


### PR DESCRIPTION
# Description

- Add template property `{{projectName}}` to add the ability of calling different scripts per project name.

## How Has This Been Tested?

This was tested using a monorepo that uses Garment extensively.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)