### PR TITLE
fix: Eslint not running on lint staged

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["import", "node", "monorepo", "@typescript-eslint"],
+  "plugins": ["import", "node", "monorepo", "@typescript-eslint", "prettier"],
   "rules": {
     "node/no-extraneous-require": ["error"],
     "node/no-extraneous-import": ["error"],
@@ -16,5 +16,9 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module"
-  }
+  },
+  "extends": [
+    "plugin:prettier/recommended",
+    "prettier"
+    ]
 }

--- a/garment.json
+++ b/garment.json
@@ -44,6 +44,13 @@
     "tspackage": {
       "extends": "publishable",
       "tasks": {
+        "lint": [
+            {
+                "runner": "eslint",
+                "input": "{{projectDir}}/src/**/*.+(t|j)s?(x)",
+                "output": "{{projectDir}}/src"
+            }
+        ],
         "clean": {
           "runner": "clean",
           "input": "{{projectDir}}/lib/**/*"

--- a/local_garment/package.json
+++ b/local_garment/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@garment/cli": "^0.13.14",
-    "@garment/plugin-runner-clean": "^0.13.13",
-    "@garment/plugin-runner-ts": "^0.13.13"
+    "@garment/cli": "^0.16.0",
+    "@garment/plugin-runner-clean": "^0.16.0",
+    "@garment/plugin-runner-ts": "^0.16.0"
   }
 }

--- a/local_garment/yarn.lock
+++ b/local_garment/yarn.lock
@@ -42,21 +42,21 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@garment/cli@^0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@garment/cli/-/cli-0.13.14.tgz#4d06f740e69e250f4155c0fbfba2ae9b1afc28bb"
-  integrity sha512-mkhIGmj8zs5b00hIfjBRel2yAEzwSHxlK6DVCHhYRy/rAsj1RNg0bhbWVbw/7nrC+8iomoLS/5MMnJzO4W6vJQ==
+"@garment/cli@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/cli/-/cli-0.16.0.tgz#e326cb473288275f6dee1bcb199e2f3966e1078d"
+  integrity sha512-sLi41EP/3ug0lEUR9rLVz5lAL2diLFB2qoKuEG1IWQNDCb7PsycaVZS1264FwRNPhM4fmeNkB9hmN3bJBEtXLg==
   dependencies:
-    "@garment/garment" "^0.13.14"
-    "@garment/logger" "^0.13.13"
-    "@garment/perf" "^0.13.13"
-    "@garment/print-tree" "^0.13.13"
-    "@garment/scheduler" "^0.13.13"
-    "@garment/schematics-client" "^0.13.13"
-    "@garment/schematics-init" "^0.13.13"
-    "@garment/visualize-graph" "^0.13.13"
-    "@garment/workspace" "^0.13.13"
-    "@garment/yeoman-client" "^0.13.13"
+    "@garment/garment" "^0.16.0"
+    "@garment/logger" "^0.16.0"
+    "@garment/perf" "^0.16.0"
+    "@garment/print-tree" "^0.16.0"
+    "@garment/scheduler" "^0.16.0"
+    "@garment/schematics-client" "^0.16.0"
+    "@garment/schematics-init" "^0.16.0"
+    "@garment/visualize-graph" "^0.16.0"
+    "@garment/workspace" "^0.16.0"
+    "@garment/yeoman-client" "^0.16.0"
     chalk "^2.4.2"
     cosmiconfig "^5.2.1"
     fs-extra "8.1.0"
@@ -64,24 +64,26 @@
     update-notifier "^3.0.1"
     yargs "15.0.2"
 
-"@garment/dependency-graph@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/dependency-graph/-/dependency-graph-0.13.13.tgz#854c5e9c0b23de8b8fde5a55d8d3eeafeabd3d81"
-  integrity sha512-6mpbwMNOTJC39984i9/ilXrWc3y9tHCO7srBFiGJKXWQUQQamkJDB904g5qpRBRds4yU+trc4zxsyfxA50r/eQ==
+"@garment/dependency-graph@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/dependency-graph/-/dependency-graph-0.16.0.tgz#4f04a4a2aae72827417a254998c8047a705a9cad"
+  integrity sha512-BVppZZ9F0rpkQU5+mEn2+ARTJ0TSvTXHbnqDkbpIRDxzQ7+aOirZ1urL5MDieogrpVSKxMzN+PIwpwDjihadrw==
 
-"@garment/garment@^0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@garment/garment/-/garment-0.13.14.tgz#66e9652d7bf802ad0692df8a05560285b6e0453c"
-  integrity sha512-w23QMmkBAHc1R0qbJXj7Hlbn4YPNBzoBrOsfCTEIx4Aq890eZTram+LUf5hLpGdbbkGUbIQI6XK9sjvcHYiWog==
+"@garment/garment@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/garment/-/garment-0.16.0.tgz#7c64f373011530ee01e5d3179fb7d319ea19250c"
+  integrity sha512-X7J4KjefLKj+BKE6XbZ1l7V7Nlhsmxh2PQk1QXVDU6hJoigLcALwSOVxTi+JrA2QseuemfGhhjUfTQlyiJtlMA==
   dependencies:
-    "@garment/dependency-graph" "^0.13.13"
-    "@garment/logger" "^0.13.13"
-    "@garment/runner" "^0.13.13"
-    "@garment/scheduler" "^0.13.13"
-    "@garment/schema-validator" "^0.13.13"
-    "@garment/workspace" "^0.13.13"
-    "@parcel/watcher" "^2.0.0-alpha.5"
+    "@garment/dependency-graph" "^0.16.0"
+    "@garment/logger" "^0.16.0"
+    "@garment/runner" "^0.16.0"
+    "@garment/scheduler" "^0.16.0"
+    "@garment/schema-validator" "^0.16.0"
+    "@garment/utils" "^0.16.0"
+    "@garment/workspace" "^0.16.0"
+    "@parcel/watcher" "^2.0.0-alpha.9"
     fs-extra "8.1.0"
+    globby "10.0.1"
     is-valid-path "^0.1.1"
     matcher "^2.1.0"
     memfs "^3.1.2"
@@ -90,63 +92,63 @@
     tempy "0.3.0"
     unionfs "^4.4.0"
 
-"@garment/logger@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/logger/-/logger-0.13.13.tgz#7d8befa7393d3f315f2cd0a976581c488ea22d3f"
-  integrity sha512-XNkNeaaagGI3Dav+cGCUBlIYi9FLTh2CESfKicdZiZH4CCnR2XMoM8gekncP+NyM6uQtOLjHStkg+ohGKADRYg==
+"@garment/logger@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/logger/-/logger-0.16.0.tgz#085bd8155c48e2b1a28dca582e968a3d570138be"
+  integrity sha512-pKIrNk9FASogoju3qRpMEA1EmpjYXQ1aiwaHxvM+kq9o/uZCj3td/nbvFCSxQPQmF5mCj8h/aEqCSY94LjCS1g==
   dependencies:
     chalk "^2.4.2"
     strip-ansi "^5.2.0"
 
-"@garment/perf@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/perf/-/perf-0.13.13.tgz#df2f5283bc5fc43e1fa7738ffac23eaaf3bb70a2"
-  integrity sha512-oU2tVu5YUP749rpp7AaP/HIVtQpXJgSZjMpSxI9tuFTqGUl+Dlnh4DG3RAqyL4NBHu8Q3NqOKhCincOmd1c87w==
+"@garment/perf@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/perf/-/perf-0.16.0.tgz#d3c97e1a59506821bd4c1f727308ffe5487c3bbf"
+  integrity sha512-6LThoVVxbwnyc+3xN3zFhfvSXE9uxmVN9K8LMyjLchY7VzA0IPhZ4mnf0MZo5s0lDM0q86VEpWaT8qjX5F3LVg==
   dependencies:
-    "@garment/logger" "^0.13.13"
+    "@garment/logger" "^0.16.0"
 
-"@garment/plugin-runner-clean@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-clean/-/plugin-runner-clean-0.13.13.tgz#4170da8e63998316603175e641de2f2ecd4f7279"
-  integrity sha512-k6Z7xHfXAt+Ig1Kcn1zgGdduAdfxyG1MR55GEyCtH/3N138X+abuhDMHzT8pc1aq8CxUdrXxSYcOCsqIhqjXHg==
+"@garment/plugin-runner-clean@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-clean/-/plugin-runner-clean-0.16.0.tgz#f7d82e40b82beada57507b347aba02cb183d7324"
+  integrity sha512-fV2lqVOvuYOGZ3QiODeO7M2eevjeCLSsX1V1vSFVPZ50DQQv4vjJYwxIkPpbMaazJEyN+iSnCV1BpcHE2uFbkA==
   dependencies:
     del "^4.0.0"
 
-"@garment/plugin-runner-ts@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-ts/-/plugin-runner-ts-0.13.13.tgz#b399c0bbbb28dd21a3ad24fa0455d7ea93462075"
-  integrity sha512-zrfBux0RKTkZh1aX31nvhjvPUr3iD7t1+c/CX+7t9aNwBvJVCmWUppCm27+jDosimCyUcAS9uD218+Xd9uR34g==
+"@garment/plugin-runner-ts@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/plugin-runner-ts/-/plugin-runner-ts-0.16.0.tgz#23db3c9ae3b3ecd9962bb743e0168d3a1e72b645"
+  integrity sha512-1x3Xxhcl9CjB1uok19nfRbjMzR6QKyIDjdYPw+RFBVEHH/1wCF+ihqQxhmHegVfcxAdujhA4jrZ5X++fMMVuFg==
 
-"@garment/print-tree@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/print-tree/-/print-tree-0.13.13.tgz#4c2e58765159c53e29de8c4eace6882482f79613"
-  integrity sha512-4btM8LqvqHjv5mjmPS60pHvqMGgynsUF7kppVuEcVh14UykXXmSUWRbARizLnLYkGIIl3U7Ep00MJWkYVV/ZeQ==
+"@garment/print-tree@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/print-tree/-/print-tree-0.16.0.tgz#3ac7c2e74876b5fda3cf66613652ce78674b9a03"
+  integrity sha512-JrMinkMWg9p3X0ocWVDjodCiD9zKIh8NYcsWi4xUMrpy1xxOQAq7diUDZPP3LtNJNjc3E9dM4wCq7TBc9/b/iQ==
   dependencies:
     treeify "^1.1.0"
 
-"@garment/runner@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/runner/-/runner-0.13.13.tgz#b764a4f6411082210dabcc925473c9648e704d9e"
-  integrity sha512-239GGVUnbrXD1Cz8BTu0H7nYrZM0i/3c7vGVZLMXQtjsFJrMJdkbbNHbE2IyAb1iluQAML5KAEKNiP2xUuc4tQ==
+"@garment/runner@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/runner/-/runner-0.16.0.tgz#f709bf45d94efdad4513d90479da0bb2de769c0f"
+  integrity sha512-skKMnvE+6eR/cW/4jtYQPtPxAwiAQsHa28PJvKfYQvtt9g4ythTpXOEvzfIL6wZjkoUOnUHJ/nZ3xD8dW8uxkg==
   dependencies:
-    "@garment/logger" "^0.13.13"
-    "@garment/schema-validator" "^0.13.13"
-    "@garment/watcher" "^0.13.13"
-    "@garment/workspace" "^0.13.13"
+    "@garment/logger" "^0.16.0"
+    "@garment/schema-validator" "^0.16.0"
+    "@garment/watcher" "^0.16.0"
+    "@garment/workspace" "^0.16.0"
     "@types/fs-extra" "^5.0.5"
     fs-extra "8.1.0"
     mustache "^3.0.1"
 
-"@garment/scheduler@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/scheduler/-/scheduler-0.13.13.tgz#386930212874e9dedf71bb3aa762ca7fb4b16fcc"
-  integrity sha512-bDzxbHr+rgJa7eo15CxzUg71dwFtKnguBHIj2FSXgAYGqGgwke3LWzOjtklNbqbKVR8Kdo8jnUrrf4yv6r2wow==
+"@garment/scheduler@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/scheduler/-/scheduler-0.16.0.tgz#7335a4ec1f33e7c1c6ab2ddbd271ed0c47b484ba"
+  integrity sha512-7F0pY5dKhGcxLzFCvEWPGfuHP40stB/N66GvHOu9xuR+4pM1mo20VzgaKheCOBRe33dn1rxGVlqABC/6w21q2w==
   dependencies:
-    "@garment/dependency-graph" "^0.13.13"
-    "@garment/logger" "^0.13.13"
-    "@garment/runner" "^0.13.13"
-    "@garment/watcher" "^0.13.13"
-    "@garment/workspace" "^0.13.13"
+    "@garment/dependency-graph" "^0.16.0"
+    "@garment/logger" "^0.16.0"
+    "@garment/runner" "^0.16.0"
+    "@garment/watcher" "^0.16.0"
+    "@garment/workspace" "^0.16.0"
     "@types/glob-parent" "^3.1.1"
     fs-extra "8.1.0"
     glob-parent "^5.0.0"
@@ -157,67 +159,73 @@
     object-hash "^2.0.0"
     tempy "0.3.0"
 
-"@garment/schema-validator@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/schema-validator/-/schema-validator-0.13.13.tgz#81dae1d1be070fac1db0ec60bf5a5cd21a8025ab"
-  integrity sha512-Eo/yl9Pv9LpesdYPjK9jLiTTVCAg6tJ/Xkn3ASEAxpwYFA0SkfXZgLT81Ywp5duCGx342n1oNYViDOhql1lU8Q==
+"@garment/schema-validator@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/schema-validator/-/schema-validator-0.16.0.tgz#30c5d44924bd3fb1cdf534e7407798c44dea29a3"
+  integrity sha512-gMxPHWCGSEfJK7WioKDHk6j+RY15OEOfvr2B4AMg20riI0moNZc2b03Hf9LPxKAEkPz14zdW7E+hdHvx9tUPqQ==
   dependencies:
     ajv "^6.7.0"
 
-"@garment/schematics-client@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/schematics-client/-/schematics-client-0.13.13.tgz#a79c5b27ea653c707fb9b18d24f92a4cc8d2bde6"
-  integrity sha512-UHljfYM1YWdTVS7prNb83w7e6ATwHqIZ9AUXFIDGYVJU3Txps6oCRbBK8z5a+1bpbRpmdyn5cnPisct1egNXiQ==
+"@garment/schematics-client@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/schematics-client/-/schematics-client-0.16.0.tgz#bff8bb06856eba27e98e402eb1e81402167e32d0"
+  integrity sha512-n55mY5EGDxmxoPPLZ8Rc7SFLHMvdRPZTyt4gewF7WFMG2Lw0MX1aozVsKCnVzsseO3hYSX3DahLxpmJYVu8mow==
   dependencies:
     "@angular-devkit/core" "^7.3.1"
     "@angular-devkit/schematics" "^7.3.1"
     inquirer "^6.2.2"
     symbol-observable "^1.2.0"
 
-"@garment/schematics-init@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/schematics-init/-/schematics-init-0.13.13.tgz#8e591eb9f33bf2ae15b0ad7658a4b84a5b076e69"
-  integrity sha512-CHsHgUou54/YqJL7TMOU10nHbsRgOaIATCYddBjEyUg7TffUKGmgKzgLPua0QEkvJYCc3dJqDnCl7sNsB4r6WQ==
+"@garment/schematics-init@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/schematics-init/-/schematics-init-0.16.0.tgz#a658533478d4bc19314046773b3f9898a443f4ef"
+  integrity sha512-J6NBh81puppub/fPLCyxiFNUhhjBKGb4fCjGdvg9iBc4TEYQwfJeoSmN/spR46DakpAIql8jzRAyWPThaOyorw==
   dependencies:
     "@angular-devkit/core" "^7.3.1"
     "@angular-devkit/schematics" "^7.3.1"
     execa "^1.0.0"
 
-"@garment/visualize-graph@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/visualize-graph/-/visualize-graph-0.13.13.tgz#a3fa30e8e527de882591ce49f0e73e6fa9095e73"
-  integrity sha512-vnKD95a/hlN1jMWgDISzhpeYy+xxJx5vWhEYWE54RgIZXfMoXFBiA4UpOhX/UKxn86Ev5Umv03KpUlAK05ta7A==
+"@garment/utils@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/utils/-/utils-0.16.0.tgz#839cfa038bd5b29c4bcca1c3d7d2ffddd8d1df81"
+  integrity sha512-QEzrSnkulkzU822KR6lKXxlQx1w6DUf3gMkFriPu094nxVOBzXpMpK0SBXTedE2aIewf1ZOGqb8CK51pb6QjTw==
+
+"@garment/visualize-graph@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/visualize-graph/-/visualize-graph-0.16.0.tgz#ac0a099d4a625a818287cdb44768d87bc61bb5fb"
+  integrity sha512-Ue9MO0dytxCZ0TXgdUaC/FS2TnfaC2TDvWkJB1XNIqxt/1enLQUt/SmF3LIcqsEu2LDMLdcTMN+rfuvaxhxsKQ==
   dependencies:
-    "@garment/dependency-graph" "^0.13.13"
+    "@garment/dependency-graph" "^0.16.0"
     fs-extra "8.1.0"
     graphviz "^0.0.8"
     opn "^5.4.0"
     tmp "^0.0.33"
     viz.js "^2.1.2"
 
-"@garment/watcher@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/watcher/-/watcher-0.13.13.tgz#686244d57b38febc8d077fb2349f769afea0d793"
-  integrity sha512-sM4KZWvKBYBXmAgmgPesfw4LUiJ/o+jfF+Smj7+S1yjHPdD7TA1CU5oFwo4kheqhSoMF73vIgZo4tvnT+35Diw==
+"@garment/watcher@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/watcher/-/watcher-0.16.0.tgz#4ca1f7e65cc9d166adf8f6c02f72af3c1c63fcf5"
+  integrity sha512-nofRmp6HgC9cW3Co2kfR9sFGyPtSofWLaZYBGYPv40R+Mp3Z41rGB587oMWZc3Ev/XSrKxRLr3ryBRTotXjRQQ==
   dependencies:
     chokidar "^2.1.5"
 
-"@garment/workspace@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/workspace/-/workspace-0.13.13.tgz#72953e93968180333dab883e714d1dbdf88fe46a"
-  integrity sha512-SfssnVVwGTgy3xnFcC4omszwC1IM55ecyA55O8ITNA2SyeqnhRxFofXsi14ah46nOLr9ytNmBIzqp708SCkFMA==
+"@garment/workspace@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/workspace/-/workspace-0.16.0.tgz#7015818bd3e77e31b8bbf399f1b06a642c893a86"
+  integrity sha512-tjcm86xpxr6PIQ+6hJVsm3gG+48DqEeLv3bd69JZRBn3zVrZPKRK07tNSzGzVkwglFgkJRXGsOe3iS5VtbxQMw==
   dependencies:
-    "@garment/schema-validator" "^0.13.13"
+    "@garment/schema-validator" "^0.16.0"
+    "@garment/utils" "^0.16.0"
     dependency-graph "^0.8.0"
     fs-extra "8.1.0"
     mustache "^3.0.1"
     normalize-path "^3.0.0"
     object-hash "^2.0.0"
 
-"@garment/yeoman-client@^0.13.13":
-  version "0.13.13"
-  resolved "https://registry.yarnpkg.com/@garment/yeoman-client/-/yeoman-client-0.13.13.tgz#cebb19fa42fb39a272337dc9bc956751705d837b"
-  integrity sha512-1N/aNhsQyGCkrMHLHMDd3UdQCsGdo9roMAe0Vi2oBym1zbLbRI2J0IYUIMi+O3WsDKuIVqa9PQKl8kIZb6Z3oA==
+"@garment/yeoman-client@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@garment/yeoman-client/-/yeoman-client-0.16.0.tgz#c47a8c99462ed1cf4226b9fab2f3ba40a092ca63"
+  integrity sha512-1BSbexC4U0CwRsCUMMBGktBMf5Wv5oug210Gj+xmLoEm61O+xdITeOMaKo0QpyW55dTdEDNjSo+GWuf4vyBurg==
   dependencies:
     globby "10.0.1"
     yeoman-environment "^2.3.4"
@@ -256,14 +264,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@parcel/watcher@^2.0.0-alpha.5":
-  version "2.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0-alpha.8.tgz#7aee9504b87eebc73c794c611a6673e58b81e0b1"
-  integrity sha512-9aQu1SFkR6t1UYo3Mj1Vg39/Scaa9i4xGZnZ5Ug/qLyVzHmdjyKDyAbsbUDAd1O2e+MUhr5GI1w1FzBI6J31Jw==
+"@parcel/watcher@^2.0.0-alpha.9":
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0-alpha.10.tgz#99266189f5193512dbdf6b0faca20400c519a16e"
+  integrity sha512-8uA7Tmx/1XvmUdGzksg0+oN7uj24pXFFnKJqZr3L3mgYjdrL7CMs3PRIHv1k3LUz/hNRsb/p3qxztSkWz1IGZA==
   dependencies:
-    lint-staged "^10.0.8"
-    node-addon-api "^3.0.0"
-    node-gyp-build "^4.2.1"
+    node-addon-api "^3.0.2"
+    node-gyp-build "^4.2.3"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -317,11 +324,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
 JSONStream@^1.2.1, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -329,14 +331,6 @@ JSONStream@^1.2.1, JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
-
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
 
 ajv@6.9.1:
   version "6.9.1"
@@ -365,17 +359,12 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^3.0.0"
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -495,11 +484,6 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
-
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-each@^1.0.0, async-each@^1.0.1:
   version "1.0.3"
@@ -685,11 +669,6 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
-  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -714,7 +693,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -781,11 +760,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
 cli-boxes@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
@@ -811,14 +785,6 @@ cli-table@^0.3.1:
   integrity sha1-9TsFJmqLGguTSz0IIebi3FkUriM=
   dependencies:
     colors "1.0.3"
-
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -923,11 +889,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
-  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -974,17 +935,6 @@ cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-cosmiconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
-  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -1088,11 +1038,6 @@ decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
-
-dedent@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1247,13 +1192,6 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
 errlop@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/errlop/-/errlop-2.2.0.tgz#1ff383f8f917ae328bebb802d6ca69666a42d21b"
@@ -1314,7 +1252,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^4.0.0, execa@^4.0.3:
+execa@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
   integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
@@ -1453,7 +1391,7 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-figures@^3.0.0, figures@^3.2.0:
+figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -1575,11 +1513,6 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-own-enumerable-property-symbols@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
-  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1884,14 +1817,6 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -1901,11 +1826,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2133,7 +2053,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -2180,11 +2100,6 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
-
-is-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
-  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-retry-allowed@^1.0.0:
   version "1.2.0"
@@ -2419,41 +2334,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.8:
-  version "10.2.13"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.13.tgz#b9c504683470edfc464b7d3fe3845a5a1efcd814"
-  integrity sha512-conwlukNV6aL9SiMWjFtDp5exeDnTMekdNPDZsKGnpfQuHcO0E3L3Bbf58lcR+M7vk6LpCilxDAVks/DDVBYlA==
-  dependencies:
-    chalk "^4.1.0"
-    cli-truncate "^2.1.0"
-    commander "^6.0.0"
-    cosmiconfig "^7.0.0"
-    debug "^4.1.1"
-    dedent "^0.7.0"
-    enquirer "^2.3.6"
-    execa "^4.0.3"
-    listr2 "^2.6.0"
-    log-symbols "^4.0.0"
-    micromatch "^4.0.2"
-    normalize-path "^3.0.0"
-    please-upgrade-node "^3.2.0"
-    string-argv "0.3.1"
-    stringify-object "^3.3.0"
-
-listr2@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.6.2.tgz#4912eb01e1e2dd72ec37f3895a56bf2622d6f36a"
-  integrity sha512-6x6pKEMs8DSIpA/tixiYY2m/GcbgMplMVmhQAaLFxEtNSKLeWTGjtmU57xvv6QCm2XcqzyNXL/cTSVf4IChCRA==
-  dependencies:
-    chalk "^4.1.0"
-    cli-truncate "^2.1.0"
-    figures "^3.2.0"
-    indent-string "^4.0.0"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rxjs "^6.6.2"
-    through "^2.3.8"
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -2485,23 +2365,6 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
-
-log-symbols@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
-  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
-  dependencies:
-    chalk "^4.0.0"
-
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
-  dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -2768,12 +2631,12 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-addon-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
-  integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
+node-addon-api@^3.0.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-gyp-build@^4.2.1:
+node-gyp-build@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
@@ -2938,13 +2801,6 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
-
 p-try@^2.0.0, p-try@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -2966,13 +2822,6 @@ paged-request@^2.0.1:
   integrity sha512-C0bB/PFk9rQskD1YEiz7uuchzqKDQGgdsEHN1ahify0UUWzgmMK4NDG9fhlQg2waogmNFwEvEeHfMRvJySpdVw==
   dependencies:
     axios "^0.18.0"
-
-parent-module@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
-  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
-  dependencies:
-    callsites "^3.0.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -3085,13 +2934,6 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -3303,11 +3145,6 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
-resolve-from@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
-  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -3384,7 +3221,7 @@ rxjs@6.3.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2:
+rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
@@ -3417,11 +3254,6 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
   integrity sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -3526,24 +3358,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3662,11 +3476,6 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-string-argv@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
-  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
-
 string-template@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
@@ -3711,15 +3520,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringify-object@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
-  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
-  dependencies:
-    get-own-enumerable-property-symbols "^3.0.0"
-    is-obj "^1.0.1"
-    is-regexp "^1.0.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3849,7 +3649,7 @@ through2@^3.0.0, through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8:
+"through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -4176,11 +3976,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yaml@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
-  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
 yargs-parser@^16.1.0:
   version "16.1.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:ci": "yarn gr build --ts.configFile tsconfig.ci.json",
     "watch": "yarn gr build --watch",
     "clean": "yarn gr clean",
-    "lint": "echo Everything seems good!",
+    "lint": "yarn gr lint",
     "test": "yarn gr test",
     "test-debug": "node --inspect-brk local_garment/node_modules/.bin/garment test --runInBand", 
     "bump": "lerna version -m 'chore: Release' --conventional-commits",
@@ -32,6 +32,8 @@
     "eslint-plugin-import": "^2.15.0",
     "eslint-plugin-monorepo": "0.2.1",
     "eslint-plugin-node": "8.0.0",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-prettier": "3.4.0",
     "husky": "^1.3.1",
     "lerna": "^3.7.1",
     "lerna-update-wizard": "^0.16.0",
@@ -49,7 +51,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "prettier --write",
+      "eslint --fix",
       "git add"
     ]
   },

--- a/packages/plugin-runner-eslint/__tests__/__snapshots__/default.test.ts.snap
+++ b/packages/plugin-runner-eslint/__tests__/__snapshots__/default.test.ts.snap
@@ -16,7 +16,18 @@ Object {
       "args": Array [
         "
 /test_path/test/index.js
+  1:13  error  Insert \`;⏎\`        prettier/prettier
   1:13  error  Missing semicolon  semi
+  
+",
+      ],
+      "level": "error",
+    },
+    Object {
+      "args": Array [
+        "
+/test_path/test/foo.js
+  1:9  error  Replace \`\\"Im·still·using·vars\\";\` with \`'Im·still·using·vars';⏎\`  prettier/prettier
   1 error and 0 warnings potentially fixable with the \`--fix\` option.
 ",
       ],
@@ -27,6 +38,7 @@ Object {
         "
 /test_path/test/foo.js
   1:1  warning  Unexpected var, use let or const instead  no-var
+  1 error and 0 warnings potentially fixable with the \`--fix\` option.
 ",
       ],
       "level": "warn",
@@ -41,12 +53,14 @@ exports[`Emits fixed files 1`] = `
 Object {
   "collectedOutput": Array [
     Object {
-      "data": "const a = 10;",
+      "data": "const a = 10;
+",
       "path": "index.js",
       "type": "text",
     },
     Object {
-      "data": "let a = \\"Im still using vars\\";",
+      "data": "let a = 'Im still using vars';
+",
       "path": "foo.js",
       "type": "text",
     },
@@ -82,8 +96,9 @@ Object {
       "args": Array [
         "
 /test_path/test/index.js
+  1:13  error  Insert \`;⏎\`        prettier/prettier
   1:13  error  Missing semicolon  semi
-  1 error and 0 warnings potentially fixable with the \`--fix\` option.
+  
 ",
       ],
       "level": "error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7637,6 +7637,11 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -7703,6 +7708,13 @@ eslint-plugin-node@8.0.0:
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
+
+eslint-plugin-prettier@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8145,6 +8157,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
@@ -14006,6 +14023,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier-package-json@^2.1.0:
   version "2.1.3"


### PR DESCRIPTION
# Description

This fixes the issue #51 by adding eslint as a garment task in tspackage.
This also adds eslint-prettier-plugin so we can just use eslint to run both prettier and eslint.
Finally also fixed the version of local_garment that was still on 0.13 and now is on 0.16 (Doenst fix the issue #62 because the bump will not be made I think)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)