### PR TITLE
fix: Updates Eslint process to run with project directory

### DIFF
--- a/packages/plugin-runner-eslint/src/index.ts
+++ b/packages/plugin-runner-eslint/src/index.ts
@@ -36,9 +36,15 @@ enum SeverityLevel {
 export default defineRunner(
   defineOptionsFromJSONSchema<EslintRunnerOptions>(require('./schema.json')),
   async function(ctx) {
-    const { logger, options, input, workspace } = ctx;
+    const { logger, options, input, workspace, project } = ctx;
     const { configFile, outputDir, fix: fixFlag } = options;
     const fix = Boolean(outputDir) && fixFlag;
+
+    /*
+     * Updates the cwd to be the project
+     * In this way the TS parser will only parse the project files
+     */
+    process.chdir(project.fullPath);
 
     logger.info(`Linting files with ESLint`);
 


### PR DESCRIPTION
# Description

Currently, using garment to lint a project, the Typescript parser will parse the entire repository.
This happens because the Typescript parser will use the `process.cwd()` to know where to start the parsing.
Updating the process's current working directory to the `project.fullPath` will parse only the needed files.

## How Has This Been Tested?

Tested on a private monorepo.
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)