### PR TITLE
fix: Resolve bug on eslint when linting multi projects

### DIFF
--- a/packages/plugin-runner-eslint/src/index.ts
+++ b/packages/plugin-runner-eslint/src/index.ts
@@ -40,12 +40,6 @@ export default defineRunner(
     const { configFile, outputDir, fix: fixFlag } = options;
     const fix = Boolean(outputDir) && fixFlag;
 
-    /*
-     * Updates the cwd to be the project
-     * In this way the TS parser will only parse the project files
-     */
-    process.chdir(project.fullPath);
-
     logger.info(`Linting files with ESLint`);
 
     const cliEngineOpts: CLIEngine.Options = { fix, cwd: workspace.cwd };
@@ -58,6 +52,12 @@ export default defineRunner(
     const cli = new CLIEngine(cliEngineOpts);
 
     ctx.input(files => {
+      /*
+       * Updates the cwd to be the project
+       * In this way the TS parser will only parse the project files
+       */
+      process.chdir(project.fullPath);
+
       const fixes: File[] = [];
 
       files.forEach(file => {


### PR DESCRIPTION
# Description

In this PR https://github.com/Farfetch/garment/pull/73 I introduced a bug, when linting more than one TS project it would look for the tsconfig.json in the wrong project.


## How Has This Been Tested?

Tested on a private monorepo.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)