### PR TITLE
fix(plugin-runner-jest): Prepare plugin to deal with projects that has more than one projects

### DIFF
--- a/packages/plugin-runner-jest/__tests__/__snapshots__/getConfig.test.ts.snap
+++ b/packages/plugin-runner-jest/__tests__/__snapshots__/getConfig.test.ts.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Handle multiple projects sharing the same config, when one of the projects contains Jest Projects. 1`] = `
+Object {
+  "collectCoverage": true,
+  "projects": Array [
+    Object {
+      "rootDir": "/test_path",
+      "roots": Array [
+        "<rootDir>/foo",
+      ],
+      "testEnvironment": "jsdom",
+    },
+    Object {
+      "name": "project_1",
+      "rootDir": "/test_path/test",
+    },
+    Object {
+      "name": "project_2",
+      "rootDir": "/test_path/test",
+    },
+  ],
+  "rootDir": "/test_path",
+}
+`;
+
+exports[`Handle project that contains Jest Projects. 1`] = `
+Object {
+  "projects": Array [
+    Object {
+      "name": "project_1",
+    },
+    Object {
+      "name": "project_2",
+    },
+  ],
+  "rootDir": "/test_path/test",
+  "roots": Array [
+    "<rootDir>/",
+  ],
+  "testEnvironment": "node",
+}
+`;
+
 exports[`Handles multiple projects sharing the same config 1`] = `
 Object {
   "collectCoverage": true,

--- a/packages/plugin-runner-jest/__tests__/fixtures/basic/test/jest.projects.config.js
+++ b/packages/plugin-runner-jest/__tests__/fixtures/basic/test/jest.projects.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  projects: [
+    {name: "project_1"}, {name: "project_2"}
+  ]
+};

--- a/packages/plugin-runner-jest/__tests__/getConfig.test.ts
+++ b/packages/plugin-runner-jest/__tests__/getConfig.test.ts
@@ -41,3 +41,32 @@ test('Handles multiple projects sharing the same config and one having different
 
   expect(replaceTestPath(jestConfig, cwd)).toMatchSnapshot();
 });
+
+test('Handle multiple projects sharing the same config, when one of the projects contains Jest Projects.', async () => {
+  const cwd = await initFixture('basic');
+  const { context } = await createBatchContext<JestRunnerOptions>(
+    {
+      foo: { configFile: 'jest.config.js' },
+      test: { configFile: '{{projectDir}}/jest.projects.config.js' }
+    },
+    { cwd, schema: require('../src/schema.json') }
+  );
+
+  const jestConfig = await getConfig(context);
+
+  expect(replaceTestPath(jestConfig, cwd)).toMatchSnapshot();
+});
+
+test('Handle project that contains Jest Projects.', async () => {
+  const cwd = await initFixture('basic');
+  const { context } = await createBatchContext<JestRunnerOptions>(
+    {
+      test: { configFile: '{{projectDir}}/jest.projects.config.js' }
+    },
+    { cwd, schema: require('../src/schema.json') }
+  );
+
+  const jestConfig = await getConfig(context);
+
+  expect(replaceTestPath(jestConfig, cwd)).toMatchSnapshot();
+});

--- a/packages/plugin-runner-jest/src/index.ts
+++ b/packages/plugin-runner-jest/src/index.ts
@@ -148,7 +148,19 @@ export async function getConfig(ctx: Context<JestRunnerOptions>) {
     }
 
     if (isMultipleConfigs && jestConfig.projects) {
-      jestConfig.projects.push(projectConfig as Config.ProjectConfig);
+      if (projectConfig.projects && projectConfig.projects.length > 0) {
+        const newProjects = projectConfig.projects as Config.ProjectConfig[];
+
+        newProjects.forEach(project => {
+          if (projectConfig.rootDir) {
+            project.rootDir = projectConfig.rootDir;
+          }
+        });
+
+        jestConfig.projects.push(...newProjects);
+      } else {
+        jestConfig.projects.push(projectConfig as Config.ProjectConfig);
+      }
     } else {
       Object.assign(jestConfig, projectConfig);
     }


### PR DESCRIPTION
# Description

When we start using garment for running our playwright integration test, we found that the logic behind the config object was not ready to deal with jestConfig with more than one projects. The main reason is when we have more then one projects the configuration object is built without rootDir, forcing the runner consider only the rootDir form the root and not from the project path.

Fixes # (issue)

It was added a verification for the described scenario and an update of each object with the rootDir from the path.

## How Has This Been Tested?

It was added two scenarios on the getConfig.test.ts to cover this situation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)